### PR TITLE
Write password file without world or group permissions

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -63,7 +63,7 @@ const Papa = require('papaparse');
                 ]
             }, (filename) => {
                 const data = path.extname(filename) === '.json' ? JSON.stringify(logins) : Papa.unparse(logins);
-                fs.writeFile(filename, data, 'utf-8', (e) => {
+                fs.writeFile(filename, data, {encoding: 'utf-8', mode: '0600'}, (e) => {
                     if (e) {
                         showAlert('error', e);
                     }


### PR DESCRIPTION
Resolves issue #28 by specifying file permissions to user read/write only